### PR TITLE
Forbid duplicate properties.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,13 @@ var jsonlint = require('jsonlint-lines'),
 /**
  * @alias geojsonhint
  * @param {(string|object)} GeoJSON given as a string or as an object
+ * @param {Object} options
+ * @param {boolean} [options.noRepeatedProperties=true] forbid repeated
+ * properties. This is only available for string input, becaused parsed
+ * Objects cannot have duplicate properties.
  * @returns {Array<Object>} an array of errors
  */
-function hint(str) {
+function hint(str, options) {
 
     var gj, errors = [];
 
@@ -32,7 +36,7 @@ function hint(str) {
         }];
     }
 
-    errors = errors.concat(geojsonHintObject.hint(gj));
+    errors = errors.concat(geojsonHintObject.hint(gj, options));
 
     return errors;
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chalk": "^1.1.0",
     "concat-stream": "~1.4.4",
-    "jsonlint-lines": "~1.6.0",
+    "jsonlint-lines": "1.7.1",
     "minimist": "1.1.1",
     "text-table": "^0.2.0"
   },

--- a/test/data/bad/bad-duplicate-properties.geojson
+++ b/test/data/bad/bad-duplicate-properties.geojson
@@ -1,0 +1,5 @@
+{
+  "type": "FeatureCollection",
+  "type": "Feature",
+  "features": []
+}

--- a/test/data/bad/bad-duplicate-properties.result
+++ b/test/data/bad/bad-duplicate-properties.result
@@ -1,0 +1,14 @@
+[
+  {
+    "message": "An object contained duplicate properties, making parsing ambigous: type",
+    "line": 1
+  },
+  {
+    "message": "\"properties\" property required",
+    "line": 1
+  },
+  {
+    "message": "\"geometry\" property required",
+    "line": 1
+  }
+]

--- a/test/data/bad/bad-duplicate-properties.result-object
+++ b/test/data/bad/bad-duplicate-properties.result-object
@@ -1,0 +1,8 @@
+[
+  {
+    "message": "\"properties\" property required"
+  },
+  {
+    "message": "\"geometry\" property required"
+  }
+]

--- a/test/data/bad/bad-json.result
+++ b/test/data/bad/bad-json.result
@@ -2,6 +2,26 @@
   {
     "line": 1,
     "message": "Parse error on line 2:\n...\": \"MultiPoint\"    \"coordinates\": [[\"fo\n----------------------^\nExpecting 'EOF', '}', ':', ',', ']', got 'STRING'",
-    "error": {}
+    "error": {
+      "message": "Parse error on line 2:\n...\": \"MultiPoint\"    \"coordinates\": [[\"fo\n----------------------^\nExpecting 'EOF', '}', ':', ',', ']', got 'STRING'",
+      "hash": {
+        "text": "\"coordinates\"",
+        "token": "STRING",
+        "line": 2,
+        "loc": {
+          "first_line": 2,
+          "last_line": 2,
+          "first_column": 12,
+          "last_column": 24
+        },
+        "expected": [
+          "'EOF'",
+          "'}'",
+          "':'",
+          "','",
+          "']'"
+        ]
+      }
+    }
   }
 ]

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -46,6 +46,21 @@ test('geojsonhint', function(t) {
         });
         t.end();
     });
+    test('noRepeatedProperties option=false', function(t) {
+        t.deepEqual(geojsonhint.hint('{"type":"invalid","type":"Feature","properties":{},"geometry":null}', {
+            noRepeatedProperties: false
+        }), [], 'sketchy object permitted');
+        t.end();
+    });
+    test('noRepeatedProperties option=true', function(t) {
+        t.deepEqual(geojsonhint.hint('{"type":"invalid","type":"Feature","properties":{},"geometry":null}', {
+            noRepeatedProperties: true
+        }), [{
+          "line": 1,
+          "message": "An object contained duplicate properties, making parsing ambigous: type"
+        }], 'sketchy object not permitted by default');
+        t.end();
+    });
     test('invalid roots', function(t) {
         t.deepEqual(geojsonhint.hint('null'), [{
             message: 'The root of a GeoJSON object must be an object.',


### PR DESCRIPTION
This flags a potentially ambiguous form of JSON: objects with
duplicate properties, like

```json
{
  "type": "Feature",
  "type": "FeatureCollection"
}
```

These are valid JSON according to the specification but many
parsers will reject this input, and others will accept the second
value. This PR updates jsonlint to a new version that adds a
non-enumerable property that keeps track of duplicate properties (1.7.1)
and then adds a default-true option to forbid these properties.

cc @sgillies @perrygeo 