### PR TITLE
Change noRepeatedProperties to noDuplicateMembers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0
 
-* Introduces a new option, `noRepeatedProperties`, and a stricter default
+* Introduces a new option, `noDuplicateMembers`, and a stricter default
   behavior: repeated properties, which are ambiguous in JSON, are now forbidden
   by default with geojsonhint.
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ the GeoJSON standards and returns them as an array of errors. An example of the 
 }]
 ```
 
-The options argument is optional and has one option: `noRepeatedProperties`.
+The options argument is optional and has one option: `noDuplicateMembers`.
 By default, geojsonhint will treat repeated properties as an error: you can
-set noRepeatedProperties to false to allow them. For instance:
+set noDuplicateMembers to false to allow them. For instance:
 
 ```js
 geojsonhint.hint('{"type":"invalid","type":"Feature","properties":{},"geometry":null}', {
-    noRepeatedProperties: false
+    noDuplicateMembers: false
 });
 ```
 

--- a/bin/HELP.md
+++ b/bin/HELP.md
@@ -10,6 +10,6 @@ options:
 
   options are pretty, json, compact. pretty is the default.
 
---noRepeatedProperties
+--noDuplicateMembers
 
   if set to false, geojsonhint will permit repeated properties.

--- a/bin/geojsonhint
+++ b/bin/geojsonhint
@@ -33,7 +33,7 @@ function pluralize(word, count) {
 function hint(input) {
 
     var options = {
-      noRepeatedProperties: argv.noRepeatedProperties !== 'false'
+      noDuplicateMembers: argv.noDuplicateMembers !== 'false'
     };
 
     var errors = geojsonhint.hint(input.toString(), options);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var jsonlint = require('jsonlint-lines'),
  * @alias geojsonhint
  * @param {(string|object)} GeoJSON given as a string or as an object
  * @param {Object} options
- * @param {boolean} [options.noRepeatedProperties=true] forbid repeated
+ * @param {boolean} [options.noDuplicateMembers=true] forbid repeated
  * properties. This is only available for string input, becaused parsed
  * Objects cannot have duplicate properties.
  * @returns {Array<Object>} an array of errors

--- a/object.js
+++ b/object.js
@@ -2,7 +2,7 @@
  * @alias geojsonhint
  * @param {(string|object)} GeoJSON given as a string or as an object
  * @param {Object} options
- * @param {boolean} [options.noRepeatedProperties=true] forbid repeated
+ * @param {boolean} [options.noDuplicateMembers=true] forbid repeated
  * properties. This is only available for string input, becaused parsed
  * Objects cannot have duplicate properties.
  * @returns {Array<Object>} an array of errors
@@ -13,10 +13,10 @@ function hint(gj, options) {
 
     function root(_) {
 
-        if ((!options || options.noRepeatedProperties !== false) &&
+        if ((!options || options.noDuplicateMembers !== false) &&
            _.__duplicateProperties__) {
             errors.push({
-                message: 'An object contained duplicate properties, making parsing ambigous: ' + _.__duplicateProperties__.join(', '),
+                message: 'An object contained duplicate members, making parsing ambigous: ' + _.__duplicateProperties__.join(', '),
                 line: _.__line__
             });
         }

--- a/test/data/bad/bad-duplicate-properties.result
+++ b/test/data/bad/bad-duplicate-properties.result
@@ -1,6 +1,6 @@
 [
   {
-    "message": "An object contained duplicate properties, making parsing ambigous: type",
+    "message": "An object contained duplicate members, making parsing ambigous: type",
     "line": 1
   },
   {

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -57,7 +57,7 @@ test('geojsonhint', function(t) {
             noDuplicateMembers: true
         }), [{
           "line": 1,
-          "message": "An object contained duplicate properties, making parsing ambigous: type"
+          "message": "An object contained duplicate members, making parsing ambigous: type"
         }], 'sketchy object not permitted by default');
         t.end();
     });

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -46,15 +46,15 @@ test('geojsonhint', function(t) {
         });
         t.end();
     });
-    test('noRepeatedProperties option=false', function(t) {
+    test('noDuplicateMembers option=false', function(t) {
         t.deepEqual(geojsonhint.hint('{"type":"invalid","type":"Feature","properties":{},"geometry":null}', {
-            noRepeatedProperties: false
+            noDuplicateMembers: false
         }), [], 'sketchy object permitted');
         t.end();
     });
-    test('noRepeatedProperties option=true', function(t) {
+    test('noDuplicateMembers option=true', function(t) {
         t.deepEqual(geojsonhint.hint('{"type":"invalid","type":"Feature","properties":{},"geometry":null}', {
-            noRepeatedProperties: true
+            noDuplicateMembers: true
         }), [{
           "line": 1,
           "message": "An object contained duplicate properties, making parsing ambigous: type"


### PR DESCRIPTION
@tmcw for 1.2.0. Using terms from https://tools.ietf.org/html/rfc7493#section-2.3.

Duplication feels more technically clear to me. Repetition might be construed as duplicate keys immediately following eachother.