### PR TITLE
Fix error where multipolygon features have invalid coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.nyc_output

--- a/object.js
+++ b/object.js
@@ -142,10 +142,16 @@ function hint(gj, options) {
                         line: line
                     });
                 }
+            } else if (!Array.isArray(coords)) {
+                errors.push({
+                    message: 'a number was found where a coordinate array should have been found: this needs to be nested more deeply',
+                    line: line
+                });
+            } else {
+                coords.forEach(function(c) {
+                    positionArray(c, type, depth - 1, c.__line__ || line);
+                });
             }
-            coords.forEach(function(c) {
-                positionArray(c, type, depth - 1, c.__line__ || line);
-            });
         }
     }
 

--- a/test/data/bad/point-labeled-as-a-multipolygon.geojson
+++ b/test/data/bad/point-labeled-as-a-multipolygon.geojson
@@ -1,0 +1,11 @@
+{
+  "type": "Feature",
+  "properties": {},
+  "geometry": {
+    "type": "MultiPolygon",
+    "coordinates": [
+      -0.087890625,
+      51.56341232867588
+    ]
+  }
+}

--- a/test/data/bad/point-labeled-as-a-multipolygon.result
+++ b/test/data/bad/point-labeled-as-a-multipolygon.result
@@ -1,0 +1,10 @@
+[
+  {
+    "message": "a number was found where a coordinate array should have been found: this needs to be nested more deeply",
+    "line": 6
+  },
+  {
+    "message": "a number was found where a coordinate array should have been found: this needs to be nested more deeply",
+    "line": 6
+  }
+]

--- a/test/data/bad/point-labeled-as-a-multipolygon.result-object
+++ b/test/data/bad/point-labeled-as-a-multipolygon.result-object
@@ -1,0 +1,8 @@
+[
+  {
+    "message": "a number was found where a coordinate array should have been found: this needs to be nested more deeply"
+  },
+  {
+    "message": "a number was found where a coordinate array should have been found: this needs to be nested more deeply"
+  }
+]


### PR DESCRIPTION
Fixes #39

---

While this fixes #39 it does so by duplicating an error message to a different part of the error logic stack. The long block of if statements are a bit hard to read, so I think we should refactor those a bit too before merging this.

Before doing that, does this look right @tmcw?