### PR TITLE
Change error to warning message

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -134,6 +134,7 @@ function hint(gj, options) {
         if (_.length > 3) {
             return errors.push({
                 message: 'position should not have more than 3 elements',
+                level: 'message',
                 line: _.__line__ || line
             });
         }

--- a/test/data/bad/point-toomany.result
+++ b/test/data/bad/point-toomany.result
@@ -1,5 +1,6 @@
 [
   {
+    "level": "message",
     "message": "position should not have more than 3 elements",
     "line": 3
   }

--- a/test/data/bad/point-toomany.result-object
+++ b/test/data/bad/point-toomany.result-object
@@ -1,5 +1,6 @@
 [
   {
+    "level": "message",
     "message": "position should not have more than 3 elements"
   }
 ]


### PR DESCRIPTION
For positions with more than 3 elements, output a warning instead
of an error message.

This corresponds to the specification in RFC7946:

"Implementations SHOULD NOT extend positions beyond three elements
because the semantics of extra elements are unspecified and ambiguous."

Fixes #57