### PR TITLE
really long check that an object is an object

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -72,7 +72,11 @@ function hint(gj, options) {
                     line: _.__line__
                 });
             }
-        } else if (type === 'object' && _[name] !== null && _[name].__proto__ !== undefined && !Array.isArray(_[name]) && typeof _[name] === 'object') {
+        } else if (type === 'object' &&
+            (_[name] === null ||
+              Object.getPrototypeOf(Object.create(null)) !== Object.getPrototypeOf(_[name]) ||
+              Array.isArray(_[name]) ||
+              typeof _[name] !== 'object')) {
             return errors.push({
                 message: '"' + name +
                     '" member should be an' + (type),

--- a/lib/object.js
+++ b/lib/object.js
@@ -72,11 +72,10 @@ function hint(gj, options) {
                     line: _.__line__
                 });
             }
-        } else if (type === 'object' && _[name] && _[name].constructor.name !== 'Object') {
+        } else if (type === 'object' && _[name] !== null && _[name].__proto__ !== undefined && !Array.isArray(_[name]) && typeof _[name] === 'object') {
             return errors.push({
                 message: '"' + name +
-                    '" member should be ' + (type) +
-                    ', but is an ' + (_[name].constructor.name) + ' instead',
+                    '" member should be an' + (type),
                 line: _.__line__
             });
         } else if (type && typeof _[name] !== type) {


### PR DESCRIPTION
IE doesn't support `o.constructor.name` so here is a very long check that should confirm an object is really an object in most (I hope all) browsers.

ref http://stackoverflow.com/questions/25140723/constructor-name-is-undefined-in-internet-explorer

Tests are being wonky locally... going to see what happens on CI.