### PR TITLE
exit with 1 if there are any errors

### DIFF
--- a/bin/geojsonhint
+++ b/bin/geojsonhint
@@ -63,4 +63,9 @@ function hint(input) {
     } else {
         throw new Error('Format unknown');
     }
+
+    var shouldFail = errors.some(function(e) {
+        return e.level !== 'message'
+    });
+    if (shouldFail) process.exitCode = 1
 }

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -62,6 +62,31 @@ test('geojsonhint', function(t) {
         });
         t.end();
     });
+    test('binary exits with 1 for bad files', function(t) {
+        var bin = path.join(__dirname, '../bin/geojsonhint')
+        var f = glob.sync('test/data/bad/*.geojson')[0];
+        t.test(f + ' pretty', function(tt) {
+            exec(bin + ' ' + f, function(err, output) {
+                tt.ok(err, 'missing error');
+                tt.equal(err.code, 1);
+                // rule out errors we don't expect
+                tt.equal(err.killed, false);
+                tt.equal(err.signal, null);
+                tt.end();
+            });
+        });
+        t.test(f + ' json', function(tt) {
+            exec(bin + ' ' + f + ' --format=json', function(err, output) {
+                tt.ok(err, 'missing error');
+                tt.equal(err.code, 1);
+                // rule out errors we don't expect
+                tt.equal(err.killed, false);
+                tt.equal(err.signal, null);
+                tt.end();
+            });
+        });
+        t.end();
+    });
     test('validates incorrect files as objects', function(t) {
         glob.sync('test/data/bad/*.geojson').forEach(function(f) {
             if (f === 'test/data/bad/bad-json.geojson') return;


### PR DESCRIPTION
Right now, the `geojsonhint` command line tool is not very usable, as it doesn't exit with a non-zero code if there are any errors. In order to be able to use `geojsonhint` in e.g. npm `test` scripts, **this PR makes it exit with `1`** if there are any hints with a level other than `message`.

This is a breaking change.