### PR TITLE
use constructor rather than `constructor.name` for IE11

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -72,7 +72,7 @@ function hint(gj, options) {
                     line: _.__line__
                 });
             }
-        } else if (type === 'object' && _[name] && _[name].constructor.name !== 'Object') {
+        } else if (type === 'object' && _[name] && _[name].constructor !== Object) {
             return errors.push({
                 message: '"' + name +
                     '" member should be ' + (type) +


### PR DESCRIPTION
IE11 gives undefined for this :`({}).constructor.name`. 

This PR changes the requiredProperty function to check the identity of the constructor rather than the name of it.

fixes #69 and mapbox/mapbox-gl-draw#666

Although this fixes the 99% case, I recommend finding another way of checking for validity, since this will fail for objects created with `Object.create(null)`.