### PR TITLE
👉 Add option for right-hand rule validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ With this option enabled, geojsonhint will produce these warnings:
 
 Without this option, this input will pass without errors.
 
+`rightHandRule`.
+
+By default, geojsonhint will reject Polyons and MultiPolygons with linear rings that do not follow
+the right-hand rule: you can set `rightHandRule` to `false` to skip this validation. For instance:
+
+```js
+geojsonhint.hint('{"type":"Feature","properties":{...},"geometry":{...}}', {
+    rightHandRule: false
+});
+```
+
+By default the `rightHandRule` option is set to `true`, and geojsonhint will produce these warnings:
+
+```js
+[{
+  line: 1,
+  level: 'message',
+  message: 'Polygons and MultiPolygons should follow the right-hand rule',
+}]
+```
+
+
 ## Line Numbers
 
 Note that the GeoJSON can be given as a **string or as an object**. Here's how

--- a/bin/HELP.md
+++ b/bin/HELP.md
@@ -13,3 +13,7 @@ options:
 --noDuplicateMembers
 
   if set to false, geojsonhint will permit repeated properties.
+
+--rightHandRule
+
+  if set to false, geojsonhint will not reject Polygons that do not follow the right-hand rule

--- a/bin/geojsonhint
+++ b/bin/geojsonhint
@@ -23,7 +23,8 @@ if (argv._[0]) {
 function hint(input) {
 
     var options = {
-      noDuplicateMembers: argv.noDuplicateMembers !== 'false'
+      noDuplicateMembers: argv.noDuplicateMembers !== 'false',
+      rightHandRule: argv.rightHandRule !== 'false'
     };
 
     var errors = geojsonhint.hint(input.toString(), options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ var jsonlint = require('jsonlint-lines'),
  * Objects cannot have duplicate properties.
  * @param {boolean} [options.precisionWarning=true] warn if GeoJSON contains
  * unnecessary coordinate precision.
+ * @param {boolean} [options.rightHandRule=true] warn if GeoJSON contains
+ * linear ring winding that does not follow the right-hand rule.
  * @returns {Array<Object>} an array of errors
  */
 function hint(str, options) {

--- a/lib/object.js
+++ b/lib/object.js
@@ -9,6 +9,8 @@ var rightHandRule = require('./rhr');
  * Objects cannot have duplicate properties.
  * @param {boolean} [options.precisionWarning=true] warn if GeoJSON contains
  * unnecessary coordinate precision.
+ * @param {boolean} [options.rightHandRule=true] warn if GeoJSON contains
+ * linear ring winding that does not follow the right-hand rule.
  * @returns {Array<Object>} an array of errors
  */
 function hint(gj, options) {
@@ -305,7 +307,9 @@ function hint(gj, options) {
         bbox(polygon);
         if (!requiredProperty(polygon, 'coordinates', 'array')) {
             if (!positionArray(polygon.coordinates, 'LinearRing', 2)) {
-                rightHandRule(polygon, errors);
+                if (!options || options.rightHandRule !== false) {
+                    rightHandRule(polygon, errors);
+                }
             }
         }
     }
@@ -316,7 +320,9 @@ function hint(gj, options) {
         bbox(multiPolygon);
         if (!requiredProperty(multiPolygon, 'coordinates', 'array')) {
             if (!positionArray(multiPolygon.coordinates, 'LinearRing', 3)) {
-                rightHandRule(multiPolygon, errors);
+                if (!options || options.rightHandRule !== false) {
+                    rightHandRule(multiPolygon, errors);
+                }
             }
         }
     }

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -156,6 +156,14 @@ test('geojsonhint', function(t) {
         });
         t.end();
     });
+    t.test('rightHandRule option=false', function(t) {
+        var badRhrFeature = path.join(__dirname, '../test/data/bad/bad-polygon-interiorring-rhr.geojson');
+
+        t.deepEqual(geojsonhint.hint(filejs(badRhrFeature), {
+            rightHandRule: false
+        }), [], 'Linear ring with non right-hand winding in object permitted');
+        t.end();
+    });
     test('invalid roots', function(t) {
         t.deepEqual(geojsonhint.hint('null'), [{
             message: 'The root of a GeoJSON object must be an object.',


### PR DESCRIPTION
This PR adds an option that allows users to disable [Right Hand Rule](https://tools.ietf.org/html/rfc7946#section-3.1.6) (RHR) validation on Polygon and MultiPolygon linear rings by setting a new `rightHandRule` option to `false`. The default behavior still enforces the RHR.

This allows for backwards compatibility with the previous spec:

```
   Note: the [GJ2008] specification did not discuss linear ring winding
   order.  For backwards compatibility, parsers SHOULD NOT reject
   Polygons that do not follow the right-hand rule.
```

The rationale for this is that many available tools have not yet implemented the RHR when generating geometries, resulting in end users getting validation errors for otherwise "valid" geometries when using `geojsonhint`.

Example Usage:
```
geojsonhint.hint({...GEOJSON...}, {
    rightHandRule: false
});
```
Thanks and looking forward to any feedback! 



