### PR TITLE
Option to disable RHR 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 3.1.0
+
+* Adds options to disable right-hand rule validation [#87](https://github.com/mapbox/geojsonhint/pull/87)
+
 ## 3.0.2
 
 * Bump underscore to 1.12.1
 
- 
 ## 3.0.1
 
 * Bump minimist to >v1.2.5

--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ With this option enabled, geojsonhint will produce these warnings:
 
 Without this option, this input will pass without errors.
 
+`ignoreRightHandRule`.
+
+GeoJSON specification defined that linear rings must follow right-hand rule, but also says that for backward compatibility reasons parsers should not rejects polygons wiht incorrect winding order. For that kind of situations geojsonhint has an option `ignoreRightHandRule` which is `false` by default. Setting this option to `true` will cause geojsonhint to skip right-hand rule validation.
+
+```js
+geojsonhint.hint(geojsonWithIncorrectWindingOrder, {
+  ignoreRightHandRule: true
+});
+````
+
+with this option enabled, geojsonhint will not validate winding order.
+
 ## Line Numbers
 
 Note that the GeoJSON can be given as a **string or as an object**. Here's how

--- a/bin/geojsonhint
+++ b/bin/geojsonhint
@@ -23,7 +23,8 @@ if (argv._[0]) {
 function hint(input) {
 
     var options = {
-      noDuplicateMembers: argv.noDuplicateMembers !== 'false'
+      noDuplicateMembers: argv.noDuplicateMembers !== 'false',
+      ignoreRightHandRule: argv.ignoreRightHandRule === 'true'
     };
 
     var errors = geojsonhint.hint(input.toString(), options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ var jsonlint = require('jsonlint-lines'),
  * Objects cannot have duplicate properties.
  * @param {boolean} [options.precisionWarning=true] warn if GeoJSON contains
  * unnecessary coordinate precision.
+ * @param {boolean} [options.ignoreRightHandRule=false] ignore errors if the
+ * winding order of a polygon is not correct.
  * @returns {Array<Object>} an array of errors
  */
 function hint(str, options) {

--- a/lib/object.js
+++ b/lib/object.js
@@ -9,6 +9,8 @@ var rightHandRule = require('./rhr');
  * Objects cannot have duplicate properties.
  * @param {boolean} [options.precisionWarning=true] warn if GeoJSON contains
  * unnecessary coordinate precision.
+ * @param {boolean} [options.ignoreRightHandRule=false] ignore errors if the
+ * winding order of a polygon is not correct.
  * @returns {Array<Object>} an array of errors
  */
 function hint(gj, options) {
@@ -303,22 +305,20 @@ function hint(gj, options) {
     function Polygon(polygon) {
         crs(polygon);
         bbox(polygon);
-        if (!requiredProperty(polygon, 'coordinates', 'array')) {
-            if (!positionArray(polygon.coordinates, 'LinearRing', 2)) {
-                rightHandRule(polygon, errors);
-            }
-        }
+        if (requiredProperty(polygon, 'coordinates', 'array')) return;
+        if (positionArray(polygon.coordinates, 'LinearRing', 2)) return;
+        if (options && options.ignoreRightHandRule === true) return;
+        rightHandRule(polygon, errors);
     }
 
     // https://tools.ietf.org/html/rfc7946#section-3.1.7
     function MultiPolygon(multiPolygon) {
         crs(multiPolygon);
         bbox(multiPolygon);
-        if (!requiredProperty(multiPolygon, 'coordinates', 'array')) {
-            if (!positionArray(multiPolygon.coordinates, 'LinearRing', 3)) {
-                rightHandRule(multiPolygon, errors);
-            }
-        }
+        if (requiredProperty(multiPolygon, 'coordinates', 'array')) return;
+        if (positionArray(multiPolygon.coordinates, 'LinearRing', 3)) return;
+        if (options && options.ignoreRightHandRule === true) return;
+        rightHandRule(multiPolygon, errors);
     }
 
     // https://tools.ietf.org/html/rfc7946#section-3.1.4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/geojsonhint",
   "description": "validate and sanity-check geojson files",
-  "version": "3.0.2",
+  "version": "3.1.0-beta.1",
   "author": "Tom MacWright",
   "bin": {
     "geojsonhint": "./bin/geojsonhint"

--- a/test/hint.test.js
+++ b/test/hint.test.js
@@ -156,6 +156,39 @@ test('geojsonhint', function(t) {
         });
         t.end();
     });
+    test('ignoreRightHandRule set as true', function(t) {
+        let invalidRHR = filejs('test/data/bad/bad-polygon-interiorring-rhr.geojson');
+        let errors = geojsonhint.hint(invalidRHR, {
+            ignoreRightHandRule: true
+        })
+        t.same(errors, [], 'right hand rule should be ignored when option is explicitly set to true');
+        t.end();
+    });
+    test('ignoreRightHandRule set as false', function(t) {
+        let invalidRHR = filejs('test/data/bad/bad-polygon-interiorring-rhr.geojson');
+        let result = filejs('test/data/bad/bad-polygon-interiorring-rhr.result-object')
+        let errors = geojsonhint.hint(invalidRHR, {
+            ignoreRightHandRule: false
+        })
+        t.same(errors, result, 'right-hand rule should not be ignored if not set explicitly to true');
+        t.end();
+    });
+    test('ignoreRightHandRule is null', function(t) {
+        let invalidRHR = filejs('test/data/bad/bad-polygon-interiorring-rhr.geojson');
+        let result = filejs('test/data/bad/bad-polygon-interiorring-rhr.result-object')
+        let errors = geojsonhint.hint(invalidRHR, {
+            ignoreRightHandRule: null
+        })
+        t.same(errors, result, 'right-hand rule should not be ignored if not set explicitly to true');
+        t.end();
+    });
+    test('ignoreRightHandRule is not in options', function(t) {
+        let invalidRHR = filejs('test/data/bad/bad-polygon-interiorring-rhr.geojson');
+        let result = filejs('test/data/bad/bad-polygon-interiorring-rhr.result-object')
+        let errors = geojsonhint.hint(invalidRHR, {})
+        t.same(errors, result, 'right-hand rule should not be ignored if not set explicitly to true');
+        t.end();
+    });
     test('invalid roots', function(t) {
         t.deepEqual(geojsonhint.hint('null'), [{
             message: 'The root of a GeoJSON object must be an object.',


### PR DESCRIPTION
Adds an option to disable right-hand rule validation for Polygons and Multipolygons. 

PR includes code changes and tests and light doc changes.