### PR TITLE
upgrade underscore to 1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+* Bump underscore to 1.12.1
+
+ 
 ## 3.0.1
 
 * Bump minimist to >v1.2.5

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/geojsonhint",
   "description": "validate and sanity-check geojson files",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Tom MacWright",
   "bin": {
     "geojsonhint": "./bin/geojsonhint"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "concat-stream": "^1.6.1",
     "jsonlint-lines": "1.7.1",
     "minimist": "^1.2.5",
+    "underscore": "1.12.1",
     "vfile": "^4.0.0",
     "vfile-reporter": "^5.1.1"
   },


### PR DESCRIPTION
This will fix the [vulnerability issue](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23358). 