### PR TITLE
Remove unused underscore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "concat-stream": "^1.6.1",
     "jsonlint-lines": "1.7.1",
     "minimist": "^1.2.5",
-    "underscore": "1.12.1",
     "vfile": "^4.0.0",
     "vfile-reporter": "^5.1.1"
   },


### PR DESCRIPTION
I know you're not accepting new pull requests, but this is security-related and a very small change.

The `underscore` dependency is pinned to version `1.12.1` in package.json. ~This version has a [security vulnerability](https://www.cve.org/CVERecord?id=CVE-2021-23358) that I can't resolve by upgrading underscore in my application, because geojsonhint pins an exact version.~

I was going to change it to specify a version range (`^1.12.1`), but then I realized that underscore is not actually used, so this removes it entirely. The tests pass.

EDIT: The vulnerability is actually in the version of underscore specified in the `jsonlint-lines` dependency.